### PR TITLE
fix: use is-node-process instead of checking if process is defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
   },
   "dependencies": {
     "@graphql-typed-document-node/core": "^3.2.0",
-    "graphql-request": "^6.1.0"
+    "graphql-request": "^6.1.0",
+    "is-node-process": "^1.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   graphql-request:
     specifier: ^6.1.0
     version: 6.1.0(graphql@16.8.1)
+  is-node-process:
+    specifier: ^1.2.0
+    version: 1.2.0
 
 devDependencies:
   '@apollo/client':
@@ -8590,7 +8593,6 @@ packages:
 
   /is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
-    dev: true
 
   /is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}

--- a/src/mswLoader.ts
+++ b/src/mswLoader.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "msw";
 import type { SetupWorker, StartOptions } from "msw/browser";
 import { setupWorker } from "msw/browser";
+import { isNodeProcess } from "is-node-process";
 
 export type MswParameters = {
   msw?: {
@@ -58,9 +59,9 @@ export const mswLoader = async (context: Context) => {
 
   if (viewMode === "docs" && window.__MSW_STORYBOOK__.worker) {
     worker =
-      typeof global.process === "undefined" && window.__MSW_STORYBOOK__.worker;
+      !isNodeProcess() && window.__MSW_STORYBOOK__.worker;
   } else {
-    worker = typeof global.process === "undefined" && setupWorker();
+    worker = !isNodeProcess() && setupWorker();
   }
   await worker.start(opt);
   setupHandlers(msw);


### PR DESCRIPTION
I've been working on switching my storybook over to the vite builder, and I got hung up on this. Basically, I needed to use vite's [define](https://v3.vitejs.dev/config/shared-options.html#define) facility to specify some replacements on `process.env`. Turns out, vite (via esbuild) only does static replacements in production builds. In non-production environments, this results in `window.process` being defined.

I _think_ that `storybook-msw-addon` is checking `window.process` strictly in order to determine whether or not it's running within a node context. I tried to investigate this by going back through the blame to the original commit which introduced this check, but there was no explicit explanation for the check there. So I am not totally sure whether or not this assumption is correct. A fringe benefit of the change I'm suggesting is that it does a better job self-documenting the logic here (assuming my assumption is correct).

This change introduces a new dependency, [`is-node-process`](https://github.com/mswjs/is-node-process), which is actually published by @mswjs, so I figured it would be a reasonable dep to add. It's a very small library, and the check could certainly be inlined to avoid adding a third production dependency. `is-node-process` is already a dev-dependency of `storybook-msw-addon`. If you'd rather I inline the check, lemme know and I'll push an update.