### PR TITLE
fix: Cannot read properties of undefined (reading 'worker') on docs view

### DIFF
--- a/src/mswLoader.ts
+++ b/src/mswLoader.ts
@@ -57,7 +57,7 @@ export const mswLoader = async (context: Context) => {
     return;
   }
 
-  if (viewMode === "docs" && window.__MSW_STORYBOOK__.worker) {
+  if (viewMode === "docs" && window.__MSW_STORYBOOK__ && window.__MSW_STORYBOOK__.worker) {
     worker =
       !isNodeProcess() && window.__MSW_STORYBOOK__.worker;
   } else {


### PR DESCRIPTION
When accessing docs before any of the stories it throwing an error, so I've added the missing check before testing the `.worker` property.

Screenshot of the issue:
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/21dbdb9b-30bf-4ed5-874e-b498a02083a1">

