### PR TITLE
fix: update handlers when story changes

### DIFF
--- a/src/mswLoader.ts
+++ b/src/mswLoader.ts
@@ -26,7 +26,6 @@ export const initialize = async (options?: StartOptions, handlers: RequestHandle
 
 const setupHandlers = (msw: MswParameters["msw"]) => {
   if (worker) {
-    if (window.__MSW_STORYBOOK__) return;
     worker.resetHandlers(...initialHandlers);
     if (msw) {
       if (Array.isArray(msw) && msw.length > 0) {
@@ -53,16 +52,21 @@ export const mswLoader = async (context: Context) => {
     viewMode,
   } = context;
 
-  if (!msw || (window.__MSW_STORYBOOK__ && window.__MSW_STORYBOOK__.worker)) {
+  if (!msw || isNodeProcess()) {
+    return;
+  }
+
+  if (window.__MSW_STORYBOOK__ && window.__MSW_STORYBOOK__.worker) {
+    setupHandlers(msw);
     return;
   }
 
   if (viewMode === "docs" && window.__MSW_STORYBOOK__ && window.__MSW_STORYBOOK__.worker) {
-    worker =
-      !isNodeProcess() && window.__MSW_STORYBOOK__.worker;
+    worker = window.__MSW_STORYBOOK__.worker;
   } else {
-    worker = !isNodeProcess() && setupWorker();
+    worker = setupWorker();
   }
+
   await worker.start(opt);
   setupHandlers(msw);
 


### PR DESCRIPTION
I checked the storybook in this project and it was able to handle different return types based on a Story, however it wasn't working at all for me (I use multiple handlers). The first one that gets attached for an endpoint will be the only one until the page is refreshed.

This fix updates the handlers every time the `mswLoader` runs by resetting the handlers to it's initial handlers and attaching the handlers from story.

Please let me know if I broke something else :)