### PR TITLE
fix: SB_CORE-SERVER_0002 ReferenceError: module is not defined when using Node 22.

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -1,1 +1,0 @@
-export * from "./dist/manager";

--- a/preset.js
+++ b/preset.js
@@ -1,1 +1,0 @@
-module.exports = require("./dist/preset.cjs");

--- a/preview.js
+++ b/preview.js
@@ -1,1 +1,0 @@
-export * from "./dist/preview";


### PR DESCRIPTION
Files removed are not needed given they are being mapped on exports field, and by removing them Storybook is happy and builds successfully again.